### PR TITLE
Different way of handling Media Uploads

### DIFF
--- a/-/js/admin-meta.js
+++ b/-/js/admin-meta.js
@@ -111,7 +111,7 @@ jQuery( function( $ ) {
 		frame.open();
 	});
 
-	$('#webcomic_media_preview').on('click .detach-media', function (e) {
+	$('#webcomic_media_preview').on('click', '.detach-media', function (e) {
 		e.preventDefault();
 		var id = $(e.target).parent('.webcomic_media_image').data('attachment-id');
 		detachMedia(id);

--- a/-/js/admin-meta.js
+++ b/-/js/admin-meta.js
@@ -1,18 +1,21 @@
 var wpActiveEditor;
 
 jQuery( function( $ ) {
+
+	/** DEPRECIATED: see the new approach below. **/
+
 	/** Refresh the webcomic media meta box. */
-	$( document ).on( "mousedown", ".media-modal-close,.media-modal-backdrop,.media-button-insert", function() {
+	// $( document ).on( "mousedown", ".media-modal-close,.media-modal-backdrop,.media-button-insert", function() {
 		
-		setTimeout( function() {
-			$.get( $( "[data-webcomic-admin-url]" ).data( "webcomic-admin-url" ), {
-				post: $( "#post_ID" ).val(),
-				webcomic_admin_ajax: "WebcomicPosts::ajax_media_preview"
-			}, function( data ) {
-				$( "#webcomic_media_preview" ).html( data );
-			} );
-		}, 500 );
-	} );
+	// 	setTimeout( function() {
+	// 		$.get( $( "[data-webcomic-admin-url]" ).data( "webcomic-admin-url" ), {
+	// 			post: $( "#post_ID" ).val(),
+	// 			webcomic_admin_ajax: "WebcomicPosts::ajax_media_preview"
+	// 		}, function( data ) {
+	// 			$( "#webcomic_media_preview" ).html( data );
+	// 		} );
+	// 	}, 500 );
+	// } );
 	
 	/** Dynamically update the price preview for prints. */
 	$( "#webcomic_commerce_adjust_prices_domestic,#webcomic_commerce_adjust_shipping_domestic" ).on( "change", function() {
@@ -44,3 +47,65 @@ jQuery( function( $ ) {
 		}
 	}
 } );
+
+!(function (root) {
+
+	var _ = root._
+  var wp = root.wp
+  var Backbone = root.Backbone
+  var webcomic = root.webcomic = root.webcomic || {};
+
+	/**
+	 * New meta-box that uses `wp.media.view.MediaFrame.Select` to attach
+	 * images. With this method, you can actually click `Add Media` in the
+	 * modal view rather than having to click on the `x`, which is a more 
+	 * user-friendly experience. Additionally, ONLY media uploaded to the
+	 * current post is visible, which is the behavior we want.
+	 *
+	 * This is only a proof-of-concept, but it seems to work fine.
+	 */
+	var WebcomicMediaMetabox = Backbone.View.extend({
+
+		events: {
+			'click [data-webcomic-action="open-media"]': 'openMediaFrame'
+		},
+
+		initialize: function () {
+			var self = this;
+			this.frame = new wp.media.view.MediaFrame.Select({
+				title: 'Webcomic Media',
+				multiple: false,
+				library: {
+					order: 'ASC',
+					type: 'image',
+					uploadedTo: wp.media.view.settings.post.id
+				},
+				button: {
+					text: 'Add Media'
+				}
+			});
+			this.frame.on('select', _.bind(this.onImageSelected, this));
+		},
+
+		openMediaFrame : function(e) {
+			e.preventDefault();
+			this.frame.open();
+		},
+
+		onImageSelected : function() {
+			var attachments = this.frame.state().get('selection').models;
+			var out = '';
+			_.each(attachments, _.bind(function (attachment) {
+				out += '<img src="' + attachment.get('sizes').thumbnail.url + '" />';
+			}, this));
+			this.$('#webcomic_media_preview').html(out);
+			this.frame.close();
+		}
+
+	});
+
+	root.jQuery(function () {
+		webcomic.mediaMetabox = new WebcomicMediaMetabox({ el: '#webcomic-media' }); 
+	});
+
+})(window);

--- a/-/js/admin-meta.js
+++ b/-/js/admin-meta.js
@@ -48,64 +48,50 @@ jQuery( function( $ ) {
 	}
 } );
 
-!(function (root) {
+/**
+ * New meta-box that uses `wp.media.view.MediaFrame.Select` to attach
+ * images. With this method, you can actually click `Add Media` in the
+ * modal view rather than having to click on the `x`, which is a more 
+ * user-friendly experience. Additionally, ONLY media uploaded to the
+ * current post is visible, which is the behavior we want.
+ *
+ * This is only a proof-of-concept, but it seems to work fine.
+ */
+jQuery(function ($) {
 
-	var _ = root._
-  var wp = root.wp
-  var Backbone = root.Backbone
-  var webcomic = root.webcomic = root.webcomic || {};
+	var _ = window._;
+  var wp = window.wp;
+  var frame;
 
-	/**
-	 * New meta-box that uses `wp.media.view.MediaFrame.Select` to attach
-	 * images. With this method, you can actually click `Add Media` in the
-	 * modal view rather than having to click on the `x`, which is a more 
-	 * user-friendly experience. Additionally, ONLY media uploaded to the
-	 * current post is visible, which is the behavior we want.
-	 *
-	 * This is only a proof-of-concept, but it seems to work fine.
-	 */
-	var WebcomicMediaMetabox = Backbone.View.extend({
+  var webcomicMediaFrameInit = function () {
+		frame = wp.media.frames.webcomicMedia = new wp.media.view.MediaFrame.Select({
+			title: 'Webcomic Media',
+			multiple: false,
+			library: {
+				order: 'ASC',
+				type: 'image',
+				uploadedTo: wp.media.view.settings.post.id
+			},
+			button: {
+				text: 'Add Media'
+			}
+		});
 
-		events: {
-			'click [data-webcomic-action="open-media"]': 'openMediaFrame'
-		},
-
-		initialize: function () {
-			var self = this;
-			this.frame = new wp.media.view.MediaFrame.Select({
-				title: 'Webcomic Media',
-				multiple: false,
-				library: {
-					order: 'ASC',
-					type: 'image',
-					uploadedTo: wp.media.view.settings.post.id
-				},
-				button: {
-					text: 'Add Media'
-				}
-			});
-			this.frame.on('select', _.bind(this.onImageSelected, this));
-		},
-
-		openMediaFrame : function(e) {
-			e.preventDefault();
-			this.frame.open();
-		},
-
-		onImageSelected : function() {
-			var attachments = this.frame.state().get('selection').models;
+		frame.on('select', function () {
+			var attachments = frame.state().get('selection').models;
 			var out = '';
 			_.each(attachments, _.bind(function (attachment) {
 				out += '<img src="' + attachment.get('sizes').thumbnail.url + '" />';
 			}, this));
-			this.$('#webcomic_media_preview').html(out);
-			this.frame.close();
-		}
+			$('#webcomic_media_preview').html(out);
+			frame.close();
+		});
+  }
 
-	});
+  $('[data-webcomic-action="open-media"]').on('click', function (e) {
+  	e.preventDefault();
+  	if (!frame) webcomicMediaFrameInit();
+  	frame.open();
+  });
 
-	root.jQuery(function () {
-		webcomic.mediaMetabox = new WebcomicMediaMetabox({ el: '#webcomic-media' }); 
-	});
-
-})(window);
+});

--- a/-/js/admin-meta.js
+++ b/-/js/admin-meta.js
@@ -1,21 +1,6 @@
 var wpActiveEditor;
 
 jQuery( function( $ ) {
-
-	/** DEPRECIATED: see the new approach below. **/
-
-	/** Refresh the webcomic media meta box. */
-	// $( document ).on( "mousedown", ".media-modal-close,.media-modal-backdrop,.media-button-insert", function() {
-		
-	// 	setTimeout( function() {
-	// 		$.get( $( "[data-webcomic-admin-url]" ).data( "webcomic-admin-url" ), {
-	// 			post: $( "#post_ID" ).val(),
-	// 			webcomic_admin_ajax: "WebcomicPosts::ajax_media_preview"
-	// 		}, function( data ) {
-	// 			$( "#webcomic_media_preview" ).html( data );
-	// 		} );
-	// 	}, 500 );
-	// } );
 	
 	/** Dynamically update the price preview for prints. */
 	$( "#webcomic_commerce_adjust_prices_domestic,#webcomic_commerce_adjust_shipping_domestic" ).on( "change", function() {
@@ -46,24 +31,60 @@ jQuery( function( $ ) {
 			$( "#webcomic_" + id + "_total" ).html( total.toFixed( 2 ) + " " + $( "[data-webcomic-currency]" ).data( "webcomic-currency" ) );
 		}
 	}
-} );
 
-/**
- * New meta-box that uses `wp.media.view.MediaFrame.Select` to attach
- * images. With this method, you can actually click `Add Media` in the
- * modal view rather than having to click on the `x`, which is a more 
- * user-friendly experience. Additionally, ONLY media uploaded to the
- * current post is visible, which is the behavior we want.
- *
- * This is only a proof-of-concept, but it seems to work fine.
- */
-jQuery(function ($) {
+	/**  Media MetaBox handling. */
 
 	var _ = window._;
-  var wp = window.wp;
-  var frame;
+	var wp = window.wp;
+	var frame;
+	var updating = false;
 
-  var webcomicMediaFrameInit = function () {
+	var disableMetaBox = function () {
+		$( '#webcomic_media_action .button' )
+			.addClass( 'button-disabled' )
+			.attr('disabled', true);
+		$( '#webcomic_media_action .spinner' )
+			.addClass( 'is-active' );
+	};
+
+	var enableMetaBox = function () {
+		$( '#webcomic_media_action .button' )
+			.removeClass( 'button-disabled' )
+			.attr('disabled', false);
+		$( '#webcomic_media_action .spinner' )
+			.removeClass( 'is-active' );
+	}
+
+	var updateMetaBox = function () {
+		if (updating) return;
+		updating = true;
+		disableMetaBox();
+		$.get( $( "[data-webcomic-admin-url]" ).data( "webcomic-admin-url" ), {
+			post: $( "#post_ID" ).val(),
+			webcomic_admin_ajax: "WebcomicPosts::ajax_media_preview"
+		}, function( data ) {
+			updating = false;
+			enableMetaBox();
+			$( "#webcomic_media_preview" ).html( data );
+		} );
+	}
+
+	var detachMedia = function ( mediaId ) {
+		if (updating) return;
+		updating = true;
+		disableMetaBox();
+		$.post( $( "[data-webcomic-admin-url]" ).data( "webcomic-admin-url" ), {
+			postId: $( "#post_ID" ).val(),
+			mediaId: mediaId,
+			webcomic_admin_ajax: "WebcomicPosts::ajax_detach_media"
+		}, function( data ) {
+			updating = false;
+			enableMetaBox();
+			$( "#webcomic_media_preview" ).html( data );
+		} )
+	}
+
+	var webcomicMediaFrameInit = function () {
 		frame = wp.media.frames.webcomicMedia = new wp.media.view.MediaFrame.Select({
 			title: 'Webcomic Media',
 			multiple: false,
@@ -77,21 +98,23 @@ jQuery(function ($) {
 			}
 		});
 
+		frame.on('close', updateMetaBox);
 		frame.on('select', function () {
-			var attachments = frame.state().get('selection').models;
-			var out = '';
-			_.each(attachments, _.bind(function (attachment) {
-				out += '<img src="' + attachment.get('sizes').thumbnail.url + '" />';
-			}, this));
-			$('#webcomic_media_preview').html(out);
+			updateMetaBox();
 			frame.close();
 		});
-  }
+	}
 
-  $('[data-webcomic-action="open-media"]').on('click', function (e) {
-  	e.preventDefault();
-  	if (!frame) webcomicMediaFrameInit();
-  	frame.open();
-  });
+	$('#webcomic_media_action .open-frame').on('click', function (e) {
+		e.preventDefault();
+		if (!frame) webcomicMediaFrameInit();
+		frame.open();
+	});
 
-});
+	$('#webcomic_media_preview').on('click .detach-media', function (e) {
+		e.preventDefault();
+		var id = $(e.target).parent('.webcomic_media_image').data('attachment-id');
+		detachMedia(id);
+	});
+
+} );

--- a/-/php/posts.php
+++ b/-/php/posts.php
@@ -652,12 +652,31 @@ class WebcomicPosts extends Webcomic {
 				<p>%s</p>
 				<h4>%s</h4>
 				<p>%s</p>",
-				__( "New Images", "webcomic" ),
-				__( "Click <strong>Add Media</strong> above and upload one or more images to attach them to this post.", "webcomic" ),
-				__( "Existing Images", "webcomic" ),
-				__( "If you've already uploaded one or more images for this post they can be attached from the <strong>Media > Library</strong> page. After saving this post find the image or images you want to attach in the Media Library and click <strong>Attach</strong> in the <strong>Uploaded to</strong> column. You may have to <strong>Detach</strong> the images first if they were uploaded to another post.", "webcomic" )
+				__( "Attach Images", "webcomic" ),
+				__( "Click <strong>Add Media</strong> above and upload one or more images to attach them to this post, or select from any existing, <strong>Unattached</strong> images.", "webcomic" ),
+				__( "Other Methods", "webcomic" ),
+				__( "If you've already uploaded one or more images for this post they can also be attached from the <strong>Media > Library</strong> page. After saving this post find the image or images you want to attach in the Media Library and click <strong>Attach</strong> in the <strong>Uploaded to</strong> column. You may have to <strong>Detach</strong> the images first if they were uploaded to another post.", "webcomic" )
 			);
 		}
+	}
+
+	/**
+	 * Attach media to the given post.
+	 *
+	 * @param integer $post_id The parent post.
+	 * @param integer $attachment_id The ids of the attachment to attach.
+	 * @uses self::ajax_media_preview
+	 */
+	public static function ajax_attach_media( $post_id, $attachment_ids ) {
+		foreach ( $attachment_ids as $id ) {
+			$post = get_post( $id );
+			if ( $post->post_parent == $post_id ) {
+				continue;
+			}
+			$post->post_parent = $post_id;
+			wp_update_post($post);
+		}
+		self::ajax_media_preview( $post_id );
 	}
 	
 	/**


### PR DESCRIPTION
I've been using Webcomic for years now, and it's pretty great! The only complaint I have is the way media uploads are handled -- having to close the modal WITHOUT hitting 'Insert Into Post" feels weird. I've tried using `wp.media.view.MediaFrame.Select` here, and I think it works pretty well. At the very least clicking `Add Media` now does what you expect it to.

Thoughts? There might be something I'm missing about the approach you chose.