### PR TITLE
Improvements to collection keyboard navigation

### DIFF
--- a/src/js/collection/common.js
+++ b/src/js/collection/common.js
@@ -27,7 +27,7 @@
 	function webcomicCommonEvents() {
 		window.addEventListener( 'scroll', webcomicInfiniteScroll );
 		document.addEventListener( 'change', webcomicSelectNavigation );
-		document.addEventListener( 'keyup', webcomicKeyboardNavigation );
+		document.addEventListener( 'keydown', webcomicKeyboardNavigation );
 		document.addEventListener( 'click', webcomicDynamicComicLoading );
 		document.documentElement.addEventListener( 'touchstart', webcomicTouchNavigationStart, false );
 		document.documentElement.addEventListener( 'touchend', webcomicTouchNavigationEnd );

--- a/src/js/collection/common.js
+++ b/src/js/collection/common.js
@@ -130,7 +130,9 @@
 			key += 'Shift';
 		}
 
-		webcomicShortcut( key, container );
+		if ( webcomicShortcut( key, container ) ) {
+			event.preventDefault();
+		}
 	}
 
 	/**
@@ -264,13 +266,15 @@
 		const anchor = container.querySelector( `.${classes[shortcut]}[href]` );
 
 		if ( ! shortcut || ! container || ! anchor ) {
-			return;
+			return false;
 		}
 
 		anchor.dispatchEvent( new MouseEvent( 'click', {
 			bubbles: true,
 			cancelable: true
 		}) );
+
+		return true;
 	}
 
 	/**

--- a/src/js/collection/common.js
+++ b/src/js/collection/common.js
@@ -115,7 +115,18 @@
 
 		if ( ! container ) {
 			return;
-		} else if ( event.shiftKey ) {
+		}
+
+		if ( event.ctrlKey ) {
+			key += 'Ctrl';
+		}
+		if ( event.altKey ) {
+			key += 'Alt';
+		}
+		if ( event.metaKey ) {
+			key += 'Meta';
+		}
+		if ( event.shiftKey ) {
 			key += 'Shift';
 		}
 


### PR DESCRIPTION
<!-- Provide a brief, descriptive summary of your changes in the Title above -->

### Change
Fix collisions between browser shortcuts and comic next/previous navigation. See commit messages for full details.

**Bug Fix** – Fixes an issue with existing functionality

### Context
Previously, keyboard modifiers (Ctrl/Alt/Meta) were ignored when looking up keyboard shortcuts. This made it impossible to use the browser's native  ArrowLeftAlt/ArrowRightAlt shortcuts for history navigation, since the plugin would also perform navigation of its own on the same shortcuts.

<!-- Why is this changes required? What problem does it solve? -->
<!-- Include a link to an open issue related to this pull request -->

### Verification
<!-- Describe how you tested your changes and check all boxes that apply -->
<!-- If a box isn't checked, please explain why -->

- [x] I have read the code of conduct and contributing guidelines
- [x] I have followed the project's coding standards
- [x] ~~I have added tests to cover all changes~~
- [x] ~~I have verified that all new and existing tests pass~~
  (N/A, there don't seem to be tests for JS)
- [x] I have tested these changes on WordPress 5.7
  (as Vagrant provisioning seems to be broken, tested by replacing `wp-content/plugins/webcomic/srv/collection/common.js` with an unminified, modified version)
- [x] I have tested these changes on PHP 7.4.16
- [x] I have tested these changes in: Firefox 86, Chromium 89
